### PR TITLE
support for text classes with foreign objects

### DIFF
--- a/d3textwrap.v0.js
+++ b/d3textwrap.v0.js
@@ -187,7 +187,10 @@ Detailed instructions at http://www.github.com/vijithassar/d3textwrap
                 // override using .classed() and for now
                 // it's nice to avoid a litany of input
                 // arguments
-				var class_list = "wrapped "+text_node.attr("class");
+				var class_list = "wrapped";
+				if (text_node.attr("class") != null) {
+					class_list += " " + text_node.attr("class");
+				}
                 // remove the text node and replace with a foreign object
                 text_node.remove();
                 var foreign_object = parent.append('foreignObject');

--- a/d3textwrap.v0.js
+++ b/d3textwrap.v0.js
@@ -182,6 +182,12 @@ Detailed instructions at http://www.github.com/vijithassar/d3textwrap
                 var styled_line_height = text_node.style('line-height');
                 // extract our desired content from the single text element
                 var text_to_wrap = text_node.text();
+				// the class wrapped is currently hardcoded
+                // probably not necessary but easy to
+                // override using .classed() and for now
+                // it's nice to avoid a litany of input
+                // arguments
+				var class_list = "wrapped "+text_node.attr("class");
                 // remove the text node and replace with a foreign object
                 text_node.remove();
                 var foreign_object = parent.append('foreignObject');
@@ -195,12 +201,7 @@ Detailed instructions at http://www.github.com/vijithassar/d3textwrap
                 // insert an HTML div
                 var wrap_div = foreign_object
                     .append('xhtml:div')
-                    // this class is currently hardcoded
-                    // probably not necessary but easy to
-                    // override using .classed() and for now
-                    // it's nice to avoid a litany of input
-                    // arguments
-                    .attr('class', 'wrapped');
+                    .attr('class', class_list);
                 // set div to same dimensions as foreign object
                 wrap_div
                     .style('height', bounds.height)


### PR DESCRIPTION
Hello, 

This modification makes it so that any class defined in the text object is kept in the div inside the foreign objects (in addition to the wrapped class). That way you can write something like this:

```
d3.selectAll('text').each(function(d) {
		d3.select(this).classed("additional classes "+d.someAttr, true);

		bounds = { /* define bounds */ };
		d3.select(this).textwrap(bounds); 
	});
```
and if d.someAttr = someClass, the div inside the foreign object will be defined like this:
`<div class="wrapped additional classes someClass" ...>`

This is useful if you want to apply different styles to different text objects.