### PR TITLE
cast attribute strings to number

### DIFF
--- a/src/textwrap.js
+++ b/src/textwrap.js
@@ -163,8 +163,8 @@ wrap.tspans = function(text, dimensions, padding) {
     }
     if (typeof padding === 'number') {
         text
-            .attr('y', text.attr('y') + padding)
-            .attr('x', text.attr('x') + padding);
+            .attr('y', +text.attr('y') + padding)
+            .attr('x', +text.attr('x') + padding);
     }
 };
 


### PR DESCRIPTION
Cast attribute strings to number before adding padding. Fixes #13.