### PR TITLE
preserve initial position of foreignobject

### DIFF
--- a/src/textwrap.js
+++ b/src/textwrap.js
@@ -113,8 +113,8 @@ wrap.foreignobject = function(text, dimensions, padding) {
         .attr('height', dimensions.height);
     if (typeof padding === 'number') {
         foreignobject
-            .attr('x', padding)
-            .attr('y', padding);
+            .attr('x', +text.attr('x') + padding)
+            .attr('y', +text.attr('y') + padding);
     }
     // insert an HTML div
     div = foreignobject


### PR DESCRIPTION
Fixes #19. Looks like this has always been a substantial bug in the `foreignObject` positioning logic – oops! – so infuriatingly this tiny tweak needs to be a breaking change. My apologies!