### PR TITLE
tspan y position bug

### DIFF
--- a/src/textwrap.js
+++ b/src/textwrap.js
@@ -163,8 +163,8 @@ wrap.tspans = function(text, dimensions, padding) {
     }
     if (typeof padding === 'number') {
         text
-            .attr('y', +text.attr('y') + padding)
-            .attr('x', +text.attr('x') + padding);
+            .attr('y', + Number(text.attr('y')) + padding)
+            .attr('x', + Number(text.attr('x')) + padding);
     }
 };
 


### PR DESCRIPTION
When using tspan mode and having already a position applied to the original svg text, then this attribute is read as a text and the concatenation produces wrong results. turning them into a number first fixes the problem. 